### PR TITLE
v1.4, manual forms, normalization, ranking

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "net.mdln.englisc"
         minSdkVersion 22
         targetSdkVersion 29
-        versionCode 103
-        versionName "1.3"
+        versionCode 104
+        versionName "1.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/src/androidTest/java/net/mdln/englisc/DictTest.java
+++ b/app/src/androidTest/java/net/mdln/englisc/DictTest.java
@@ -24,6 +24,9 @@ public class DictTest {
                 /* phrase search in modern English */ {"to write", "mis-writan"},
                 /* frequent word that should match canonical entry */ {"thaet", "þæt"},
                 /* word with non-ASCII characters in search */ {"þrittig", "þritig"},
+                /* variant spelling of very common word */ {"þonne", "þanne"},
+                /* manually-added variant */ {"Swylce", "swilc"},
+
         };
         Context ctx = InstrumentationRegistry.getInstrumentation().getTargetContext();
         try (SQLiteDatabase db = DictDB.get(ctx)) {
@@ -50,5 +53,10 @@ public class DictTest {
     @Test
     public void normalizeQuery() {
         assertEquals("thaet", Dict.normalizeQuery("þæt"));
+    }
+
+    @Test
+    public void normalizeAccentedQuery() {
+        assertEquals("aela", Dict.normalizeQuery("\u01fd-l\u00e1!"));
     }
 }

--- a/db/build_dict_db.sh
+++ b/db/build_dict_db.sh
@@ -14,4 +14,5 @@ bzip2 -ckd db/oe_bosworthtoller.txt.bz2 | db/parse_scanned_bt.py > db/oe_bt.json
 head "-${DICT_LIMIT_LINES:-1000000000}" < db/generator-output.txt > db/generator-output-trimmed.txt
 
 db/gen_db.py ${DICT_LIMIT_LINES:+--limit $DICT_LIMIT_LINES} --bt-dict db/oe_bt.json \
-    --inflections db/generator-output-trimmed.txt --abbrevs db/oebt_abbreviations.xml --output app/src/main/res/raw/dictdb
+    --inflections db/generator-output-trimmed.txt --abbrevs db/oebt_abbreviations.xml --extra-forms db/extra-forms.txt \
+    --output app/src/main/res/raw/dictdb

--- a/db/extra-forms.txt
+++ b/db/extra-forms.txt
@@ -1,0 +1,12 @@
+ic me,mec,min
+þu þe,þec,þin
+wit unc,uncer
+git inc,incer
+we us,ure
+ge eow,eower
+he hine,his,him,hit,heo,hie,hi,hy,hire,hira
+se seo,þone,þæt,þæs,þam,þæm,þy,þon,þære,þa,þara,þæra
+þes þisne,þis,þeos,þas,þisses,þissum,þys,þisse,þisre,þas,þissa,þisra
+þanne þænne,þonne
+swilc swelc,swelce,swelces,swelcne,swelcre,swilca,swilcan,swilcere,swilcne,swilcum,swylc,swylce,swylces,swylcne,swylcra,swylcum,swylic
+micel micle,micles,miclum,miclung

--- a/db/normalize.py
+++ b/db/normalize.py
@@ -206,10 +206,10 @@ def ascify(s: str) -> str:
     as search terms.
     """
     s = s.lower()
+    s = unicodedata.normalize('NFKD', s)
     s = s.replace('æ', 'ae')
     s = s.replace('þ', 'th')
     s = s.replace('ð', 'th')
-    s = unicodedata.normalize('NFKD', s)
     s = re.sub('[^a-z ]', '', s)
     s = re.sub('[^a-z]+', ' ', s).strip()
     return s


### PR DESCRIPTION
- Add explicit list of extra forms to index.
- Improve normalization both in indexing and lookup to behave more reasonably in the presence of accesnts.
- Improve ranking of common words by pre-scoring inside SQL to make sure the Java scorer sees the best matches.