### PR TITLE
fix a bug in TermHistory

### DIFF
--- a/app/src/androidTest/java/net/mdln/englisc/TermHistoryTest.java
+++ b/app/src/androidTest/java/net/mdln/englisc/TermHistoryTest.java
@@ -19,6 +19,7 @@ public class TermHistoryTest {
         try (TermHistory history = new TermHistory(ctx, TermHistory.Location.IN_MEMORY, 0)) {
             history.recordId(100, 1000);
             history.recordId(101, 1001);
+            history.recordId(101, 1002);
             Set<Integer> expectedIds = new HashSet();
             assertEquals(expectedIds, history.getIds(0));
             expectedIds.add(101);

--- a/app/src/main/java/net/mdln/englisc/TermHistory.java
+++ b/app/src/main/java/net/mdln/englisc/TermHistory.java
@@ -33,7 +33,7 @@ public class TermHistory implements AutoCloseable {
     Set<Integer> getIds(int limit) {
         SQLiteDatabase db = databaseHelper.getReadableDatabase();
         Set<Integer> ids = new HashSet<>();
-        String sql = "SELECT nid FROM history ORDER BY timestamp_secs DESC LIMIT " + limit;
+        String sql = "SELECT DISTINCT nid FROM history ORDER BY timestamp_secs DESC LIMIT " + limit;
         try (Cursor cursor = db.rawQuery(sql, new String[]{})) {
             while (cursor.moveToNext()) {
                 ids.add(cursor.getInt(0));


### PR DESCRIPTION
...where it would return the wrong number of items if you visited a term multiple times.

For #33.