### PR TITLE
make UI test of history more robust

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,7 +27,6 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.3.0'
     androidTestImplementation 'androidx.test:rules:1.3.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-web:3.3.0'
     api 'com.google.auto.value:auto-value-annotations:1.6.6'

--- a/app/src/androidTest/java/net/mdln/englisc/MainActivityTest.java
+++ b/app/src/androidTest/java/net/mdln/englisc/MainActivityTest.java
@@ -5,7 +5,6 @@ import android.widget.EditText;
 import android.widget.ImageButton;
 
 import androidx.appcompat.widget.Toolbar;
-import androidx.test.espresso.contrib.RecyclerViewActions;
 import androidx.test.espresso.web.webdriver.Locator;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.ActivityTestRule;
@@ -15,11 +14,11 @@ import org.junit.Test;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static androidx.test.espresso.action.ViewActions.clearText;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
 import static androidx.test.espresso.action.ViewActions.typeText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
-import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withParent;
@@ -59,9 +58,10 @@ public class MainActivityTest {
         onView(allOf(
                 isAssignableFrom(ImageButton.class),
                 withParent(isAssignableFrom(Toolbar.class)))).perform(click());
-        // The last item we viewed was "Mt." Check that it's the first item in the history list.
-        onView(withId(R.id.search_results)).perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
-        onView(withId(R.id.defn_toolbar)).check(matches(hasDescendant(withText("Mt."))));
+        // The last item we viewed was "Mt." Clear the search box so that we see history and check
+        // that it's the first item in the history list.
+        onView(isAssignableFrom(EditText.class)).perform(clearText());
+        onView(new RecyclerViewMatcher(R.id.search_results).atPosition(0)).check(matches(withText(containsString("Mt."))));
     }
 
     @Test

--- a/app/src/androidTest/java/net/mdln/englisc/RecyclerViewMatcher.java
+++ b/app/src/androidTest/java/net/mdln/englisc/RecyclerViewMatcher.java
@@ -1,0 +1,75 @@
+package net.mdln.englisc;
+
+import android.content.res.Resources;
+import android.view.View;
+
+import androidx.recyclerview.widget.RecyclerView;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Based on https://gist.github.com/baconpat/8405a88d04bd1942eb5e430d33e4faa2, which is Patrick
+ * Bacon's fork of RecyclerViewMatcher from https://github.com/dannyroa/espresso-samples.
+ * Marked as MIT-licensed, though the original was Apache-2.0-licensed. See
+ * https://spin.atomicobject.com/2016/04/15/espresso-testing-recyclerviews/ for discussion.
+ */
+public class RecyclerViewMatcher {
+
+    private final int recyclerViewId;
+
+    public RecyclerViewMatcher(int recyclerViewId) {
+        this.recyclerViewId = recyclerViewId;
+    }
+
+    public Matcher<View> atPosition(final int position) {
+        return atPositionOnView(position, -1);
+    }
+
+    public Matcher<View> atPositionOnView(final int position, final int targetViewId) {
+
+        return new TypeSafeMatcher<View>() {
+            Resources resources = null;
+            View childView;
+
+            public void describeTo(Description description) {
+                String idDescription = Integer.toString(recyclerViewId);
+                if (this.resources != null) {
+                    try {
+                        idDescription = this.resources.getResourceName(recyclerViewId);
+                    } catch (Resources.NotFoundException unused) {
+                        idDescription = String.format("%s (resource name not found)", recyclerViewId);
+                    }
+                }
+
+                description.appendText("RecyclerView with id: " + idDescription + " at position: " + position);
+            }
+
+            public boolean matchesSafely(View view) {
+
+                this.resources = view.getResources();
+
+                if (childView == null) {
+                    RecyclerView recyclerView =
+                            (RecyclerView) view.getRootView().findViewById(recyclerViewId);
+                    if (recyclerView != null && recyclerView.getId() == recyclerViewId) {
+                        RecyclerView.ViewHolder viewHolder = recyclerView.findViewHolderForAdapterPosition(position);
+                        if (viewHolder != null) {
+                            childView = viewHolder.itemView;
+                        }
+                    } else {
+                        return false;
+                    }
+                }
+
+                if (targetViewId == -1) {
+                    return view == childView;
+                } else {
+                    View targetView = childView.findViewById(targetViewId);
+                    return view == targetView;
+                }
+            }
+        };
+    }
+}

--- a/app/src/main/res/raw/about.html
+++ b/app/src/main/res/raw/about.html
@@ -6,4 +6,6 @@
 
 <p>The BT pennant icon was created by <a href="https://www.davidcorrell.net/">David Correll</a>. It is released under the <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0 license</a>.</p>
 
+<p>The tests use <a href="https://gist.github.com/baconpat/8405a88d04bd1942eb5e430d33e4faa2">RecyclerViewMatcher</a> by Danny Roa and Jacob Bacon.</p>
+
 <p>Contact <a href="mailto:anglosaxon@mdln.net">anglosaxon@mdln.net</a> (or use the "Feedback" menu item) with any comments or questions.</p>


### PR DESCRIPTION
Check the result text rather than clicking on it and checking the header. This way, if the RecyclerView animations are slow, Espresso can wait until it matches.

This requires us to import `RecyclerViewMatcher`; see credits.