### PR TITLE
explicitly mark UTF-8 + bump to 403

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "net.mdln.englisc"
         minSdkVersion 22
         targetSdkVersion 29
-        versionCode 402
-        versionName "4.2"
+        versionCode 403
+        versionName "4.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/src/main/java/net/mdln/englisc/WebViewStyle.java
+++ b/app/src/main/java/net/mdln/englisc/WebViewStyle.java
@@ -28,7 +28,8 @@ public class WebViewStyle {
     }
 
     private static String styledHtml(Activity activity, String html, boolean night) {
-        String headBlock = "<head><style type=\"text/css\">" + Streams.readUtf8Resource(activity, R.raw.defn) + "</style></head>";
+        String headBlock = "<head><meta charset=\"utf-8\"><style type=\"text/css\">" +
+                Streams.readUtf8Resource(activity, R.raw.defn) + "</style></head>";
         String styleClass = night ? "dark" : "light";
         String bodyBlock = "<body class=\"" + styleClass + "\">" + html + "</body>";
         return "<html>" + headBlock + bodyBlock + "</html>";


### PR DESCRIPTION
I saw some mangled text on Moto Z Droid (Android 7.0 - SDK 24) on, e.g., "sæcocc". It looks like it's being interpreted as Latin-1. This doesn't reproduce on a Nexus 6 emulator running the same Andrioid/SDK version.