### PR TITLE
specify encoding earlier + bump versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/android:api-29
+      - image: circleci/android:api-30
     steps:
       - checkout
       - run:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,14 +1,14 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.2"
+    compileSdkVersion 30
+    buildToolsVersion "30.0.2"
     defaultConfig {
         applicationId "net.mdln.englisc"
         minSdkVersion 22
-        targetSdkVersion 29
-        versionCode 403
-        versionName "4.3"
+        targetSdkVersion 30
+        versionCode 404
+        versionName "4.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/src/main/java/net/mdln/englisc/DictDB.java
+++ b/app/src/main/java/net/mdln/englisc/DictDB.java
@@ -67,9 +67,11 @@ final class DictDB {
         File dictDBPath = new File(appCtx.getNoBackupFilesDir(), "dict.db");
         File revPath = new File(appCtx.getNoBackupFilesDir(), "dict.rev");
         if (!dictDBPath.canRead() || !revPath.canRead() || needsCopy(appCtx, revPath)) {
+            long startCopyMillis = System.currentTimeMillis();
             copyResourceToFile(appCtx, R.raw.dictdb, dictDBPath);
             copyResourceToFile(appCtx, R.raw.dictdb_rev, revPath);
-            Log.i("DictDB", "Installed new dictionary at '" + dictDBPath + "'");
+            long copyMillis = System.currentTimeMillis() - startCopyMillis;
+            Log.i("DictDB", "Installed new dictionary at '" + dictDBPath + "' in " + copyMillis + "ms." );
         }
         return SQLiteDatabase.openDatabase(dictDBPath.toString(), null, SQLiteDatabase.OPEN_READONLY);
     }

--- a/app/src/main/java/net/mdln/englisc/WebViewStyle.java
+++ b/app/src/main/java/net/mdln/englisc/WebViewStyle.java
@@ -21,15 +21,14 @@ public class WebViewStyle {
         view.getSettings().setJavaScriptEnabled(BuildConfig.DEBUG); // Espresso needs JavaScript.
         boolean night = inNightMode(activity);
         String encodedHtml = Base64.encodeToString(styledHtml(activity, html, night).getBytes(), Base64.NO_PADDING);
-        view.loadData(encodedHtml, "text/html", "base64");
+        view.loadData(encodedHtml, "text/html; charset=utf-8", "base64");
         if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK) && night) {
             WebSettingsCompat.setForceDark(view.getSettings(), WebSettingsCompat.FORCE_DARK_ON);
         }
     }
 
     private static String styledHtml(Activity activity, String html, boolean night) {
-        String headBlock = "<head><meta charset=\"utf-8\"><style type=\"text/css\">" +
-                Streams.readUtf8Resource(activity, R.raw.defn) + "</style></head>";
+        String headBlock = "<head><style type=\"text/css\">" + Streams.readUtf8Resource(activity, R.raw.defn) + "</style></head>";
         String styleClass = night ? "dark" : "light";
         String bodyBlock = "<body class=\"" + styleClass + "\">" + html + "</body>";
         return "<html>" + headBlock + bodyBlock + "</html>";

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.0.2'
     }
 }
 


### PR DESCRIPTION
- Specify encoding in `WebView.loadData` call. Moto Zs are still getting mangled text.
- Bump to 404 (4.4) and SDK 30.