### PR TITLE
SearchPendingIdlingResource

### DIFF
--- a/app/src/androidTest/java/net/mdln/englisc/MainActivityTest.java
+++ b/app/src/androidTest/java/net/mdln/englisc/MainActivityTest.java
@@ -5,6 +5,7 @@ import android.widget.EditText;
 import android.widget.ImageButton;
 
 import androidx.appcompat.widget.Toolbar;
+import androidx.test.espresso.IdlingRegistry;
 import androidx.test.espresso.web.webdriver.Locator;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.ActivityTestRule;
@@ -42,6 +43,7 @@ public class MainActivityTest {
      */
     @Test
     public void searchForAWord() {
+        IdlingRegistry.getInstance().register(new SearchPendingIdlingResource(activityRule.getActivity()));
         // SearchView has an opaque hierarchy, but there's only one EditText in it, so type
         // "forthmesto" into it. This term is only notable for having a single result, which
         // contains a clickable abbreviation.

--- a/app/src/androidTest/java/net/mdln/englisc/SearchPendingIdlingResource.java
+++ b/app/src/androidTest/java/net/mdln/englisc/SearchPendingIdlingResource.java
@@ -1,0 +1,45 @@
+package net.mdln.englisc;
+
+import androidx.test.espresso.IdlingResource;
+
+import java.util.ArrayList;
+
+/**
+ * An {@link androidx.test.espresso.IdlingResource} implementation that is idle only if
+ * {@link MainActivity} does not have any pending searches. This way {@link MainActivityTest} can
+ * be sure that when it searches for a word, it doesn't look at the top search result until the
+ * searches are all completed.
+ */
+class SearchPendingIdlingResource implements IdlingResource {
+    private final MainActivity activity;
+    private final ArrayList<ResourceCallback> callbacks = new ArrayList<>();
+
+    SearchPendingIdlingResource(MainActivity activity) {
+        this.activity = activity;
+        activity.onSearchFinished(new Runnable() {
+            @Override
+            public void run() {
+                if (isIdleNow()) {
+                    for (ResourceCallback cb : callbacks) {
+                        cb.onTransitionToIdle();
+                    }
+                }
+            }
+        });
+    }
+
+    @Override
+    public String getName() {
+        return "SearchPending";
+    }
+
+    @Override
+    public boolean isIdleNow() {
+        return activity.pendingSearches() == 0;
+    }
+
+    @Override
+    public void registerIdleTransitionCallback(ResourceCallback callback) {
+        callbacks.add(callback);
+    }
+}


### PR DESCRIPTION
`SearchPendingIdlingResource` lets the `searchForAWord` test know when it's safe to look at the rendered list of results. This removes a race where the test would fail if `searchInBackground` had not completed.