### PR TITLE
Fix dark mode on API levels 29-32

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "net.mdln.englisc"
         minSdkVersion 22
         targetSdkVersion 33
-        versionCode 506
-        versionName "5.6"
+        versionCode 507
+        versionName "5.7"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/src/main/java/net/mdln/englisc/WebViewStyle.java
+++ b/app/src/main/java/net/mdln/englisc/WebViewStyle.java
@@ -8,6 +8,7 @@ import android.util.Base64;
 import android.webkit.WebView;
 
 import androidx.webkit.WebSettingsCompat;
+import androidx.webkit.WebViewFeature;
 
 public class WebViewStyle {
     private WebViewStyle() {
@@ -24,7 +25,9 @@ public class WebViewStyle {
         String encodedHtml = Base64.encodeToString(styledHtml(activity, html, night).getBytes(), Base64.NO_PADDING);
         view.loadData(encodedHtml, "text/html; charset=utf-8", "base64");
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            WebSettingsCompat.setAlgorithmicDarkeningAllowed(view.getSettings(), true);
+            if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)) {
+                WebSettingsCompat.setAlgorithmicDarkeningAllowed(view.getSettings(), false);
+            }
         }
     }
 

--- a/app/src/main/res/raw/defn.css
+++ b/app/src/main/res/raw/defn.css
@@ -12,10 +12,27 @@ a, a:visited {
   text-decoration-style: dotted;
 }
 
-.light i {
+i {
     color: #060;
+}
+
+/* These get used for dark mode in API levels 29-32. */
+
+.dark {
+    color: #eee;
 }
 
 .dark i {
     color: #cec;
+}
+
+/* These get used for dark mode in API levels 33+. */
+
+@media (prefers-color-scheme: dark) {
+    body {
+        color: #eee;
+    }
+    i {
+        color: #cec;
+    }
 }


### PR DESCRIPTION
They don't seem to support media queries and need to have "algorithmic darkening" disabled so we can use HTML classes without getting black-on-black text.

Also bump to 5.7.