### PR TITLE
dependency bump + v5.8

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 33
+    compileSdk 33
     defaultConfig {
         applicationId "net.mdln.englisc"
         minSdkVersion 22
         targetSdkVersion 33
-        versionCode 507
-        versionName "5.7"
+        versionCode 508
+        versionName "5.8"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
@@ -21,16 +21,16 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.webkit:webkit:1.5.0'
+    implementation 'androidx.webkit:webkit:1.7.0'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test:runner:1.5.1'
+    androidTestImplementation 'androidx.test:runner:1.5.2'
     androidTestImplementation 'androidx.test:rules:1.5.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.5.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-web:3.5.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.5.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-web:3.5.1'
     api 'com.google.auto.value:auto-value-annotations:1.6.6'
     annotationProcessor 'com.google.auto.value:auto-value:1.6.6'
-    implementation 'androidx.recyclerview:recyclerview:1.2.1'
+    implementation 'androidx.recyclerview:recyclerview:1.3.1'
 }

--- a/app/src/androidTest/java/net/mdln/englisc/DictTest.java
+++ b/app/src/androidTest/java/net/mdln/englisc/DictTest.java
@@ -1,9 +1,9 @@
 package net.mdln.englisc;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;

--- a/app/src/androidTest/java/net/mdln/englisc/FeedbackTest.java
+++ b/app/src/androidTest/java/net/mdln/englisc/FeedbackTest.java
@@ -22,7 +22,6 @@ import android.net.MailTo;
 import android.widget.EditText;
 
 import androidx.test.espresso.intent.Intents;
-import androidx.test.espresso.intent.rule.IntentsTestRule;
 import androidx.test.platform.app.InstrumentationRegistry;
 
 import org.junit.Before;
@@ -33,8 +32,9 @@ import java.util.Objects;
 
 public class FeedbackTest {
 
+    @SuppressWarnings("deprecation")
     @Rule
-    public IntentsTestRule<MainActivity> intentsTestRule = new IntentsTestRule<>(MainActivity.class, true, true);
+    public androidx.test.espresso.intent.rule.IntentsTestRule<MainActivity> intentsTestRule = new androidx.test.espresso.intent.rule.IntentsTestRule<>(MainActivity.class, true, true);
 
     // Based on https://github.com/android/testing-samples/blob/master/ui/espresso/IntentsBasicSample/app/src/sharedTest/java/com/example/android/testing/espresso/IntentsBasicSample/DialerActivityTest.java.
     @Before

--- a/app/src/androidTest/java/net/mdln/englisc/MainActivityTest.java
+++ b/app/src/androidTest/java/net/mdln/englisc/MainActivityTest.java
@@ -26,16 +26,17 @@ import android.widget.ImageButton;
 import androidx.appcompat.widget.Toolbar;
 import androidx.test.espresso.web.webdriver.Locator;
 import androidx.test.platform.app.InstrumentationRegistry;
-import androidx.test.rule.ActivityTestRule;
 
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class MainActivityTest {
 
     // TODO: Migrate to https://developer.android.com/reference/androidx/test/core/app/ActivityScenario
+    @SuppressWarnings("deprecation")
     @Rule
-    public ActivityTestRule<MainActivity> activityRule = new ActivityTestRule<>(MainActivity.class, true, true);
+    public androidx.test.rule.ActivityTestRule<MainActivity> activityRule = new androidx.test.rule.ActivityTestRule<>(MainActivity.class, true, true);
 
     /**
      * Check that you can type text and click on a result to get a dialog. This just tests UI
@@ -74,6 +75,7 @@ public class MainActivityTest {
      */
     @Test
     public void searchForVerb() {
+        Assume.assumeTrue(DefnActivity.ENABLE_CONJ);
         activityRule.getActivity().setSynchronousSearches(true);
         onView(isAssignableFrom(EditText.class)).perform(typeText("mediate"), closeSoftKeyboard());
         onView(new RecyclerViewMatcher(R.id.search_results).atPosition(0))

--- a/app/src/main/java/net/mdln/englisc/DefnActivity.java
+++ b/app/src/main/java/net/mdln/englisc/DefnActivity.java
@@ -28,6 +28,7 @@ public class DefnActivity extends AppCompatActivity {
     static final String EXTRA_BTC_URL = "net.mdln.englisc.DefnActivity.BTC_URL";
     static final String BTC_URL_PREFIX = "https://btc.invalid/";
     static final String BTC_ABOUT_URL = BTC_URL_PREFIX + "about";
+    static final boolean ENABLE_CONJ = false;
     private LazyDict dict;
     private Term term;
     private Mode mode;
@@ -144,7 +145,7 @@ public class DefnActivity extends AppCompatActivity {
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.main_menu, menu);
         menu.findItem(R.id.main_menu_find).setVisible(true);
-        if (term.conjHtml() != null) {
+        if (ENABLE_CONJ && term.conjHtml() != null) {
             menu.findItem(R.id.main_menu_conj).setVisible(true);
         }
         return true;
@@ -191,7 +192,9 @@ public class DefnActivity extends AppCompatActivity {
         findViewById(R.id.defn_search).setVisibility(View.GONE);
         updateHtmlContent();
         Menu menu = ((Toolbar) findViewById(R.id.defn_toolbar)).getMenu();
-        menu.findItem(R.id.main_menu_conj).setVisible(mode == Mode.DEFN);
+        if (ENABLE_CONJ) {
+            menu.findItem(R.id.main_menu_conj).setVisible(mode == Mode.DEFN);
+        }
         menu.findItem(R.id.main_menu_defn).setVisible(mode == Mode.CONJ);
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:8.1.0'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,7 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip


### PR DESCRIPTION
Update dependencies, target SDK 33, and bump version to 5.8.

Temporarily disable the conjugation tab because it's not ready for release yet.